### PR TITLE
Issue 13 - update CI, add support for MW 1.40 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            php_version: 7.4
-            chameleon_version: 4.2.1
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: true
-            experimental: false
           - mediawiki_version: '1.39'
             php_version: 8.1
             chameleon_version: 4.2.1
@@ -31,7 +24,35 @@ jobs:
             database_image: "mysql:8"
             coverage: false
             experimental: false
-
+          - mediawiki_version: '1.40'
+            php_version: 8.1
+            chameleon_version: 4.2.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: true
+            experimental: false
+          - mediawiki_version: '1.41'
+            php_version: 8.1
+            chameleon_version: 4.2.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.42'
+            php_version: 8.2
+            chameleon_version: 4.2.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.43'
+            php_version: 8.2
+            chameleon_version: 4.2.1
+            database_type: mysql
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+            
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
       CHAMELEON_VERSION: ${{ matrix.chameleon_version }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
--include .env-39
+-include .env
 export
 
 # setup for docker-compose-ci build directory
@@ -11,10 +11,10 @@ endif
 EXTENSION := ConfIDentSkin
 
 # docker images
-MW_VERSION?=1.35
-PHP_VERSION?=7.4
-DB_TYPE?=sqlite
-DB_IMAGE?=""
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mysql:8"
 
 # extensions
 CHAMELEON_VERSION?=4.2.1

--- a/tests/node-qunit/setup.js
+++ b/tests/node-qunit/setup.js
@@ -37,6 +37,8 @@ function createDom() {
 	global.window = dom.window;
 	global.document = window.document;
 	global.Node = window.Node;
+	global.HTMLElement = dom.window.HTMLElement;
+	global.customElements = dom.window.customElements;
 	global.$ = global.jQuery = require('../../../../resources/lib/jquery/jquery.js');
 
 	return () => {


### PR DESCRIPTION
This PR is related to the issue #13.

This PR contains:

- dropped support for MW 1.35
- added support for MW 1.40, 1.41, 1.42, 1.43
- code cov upload covered by MW 1.40
- `setup.js` updated to work with the MW 1.42 and above